### PR TITLE
[ISSUE #37] 线程设置为守护线程

### DIFF
--- a/agent/src/main/kotlin/minxie/space/agent/AgentMain.kt
+++ b/agent/src/main/kotlin/minxie/space/agent/AgentMain.kt
@@ -1,7 +1,6 @@
 package minxie.space.agent
 
 
-import minxie.space.metrics.vo.MetricsContext
 import minxie.space.server.MetricHttpServer
 import minxie.space.thread.ThreadPoolAgent
 import java.lang.instrument.Instrumentation
@@ -15,6 +14,7 @@ object AgentMain {
         Thread {
             MetricHttpServer().start()
         }.let {
+            it.isDaemon = true
             it.name = "MetricHttpServer"
             it
         }.start()

--- a/metrics-server/src/main/kotlin/minxie/space/server/MetricHttpServer.kt
+++ b/metrics-server/src/main/kotlin/minxie/space/server/MetricHttpServer.kt
@@ -9,8 +9,13 @@ import io.netty.channel.socket.nio.NioServerSocketChannel
 import io.netty.handler.codec.http.HttpObjectAggregator
 import io.netty.handler.codec.http.HttpRequestDecoder
 import io.netty.handler.codec.http.HttpResponseEncoder
-import minxie.space.jvm.vo.metrics.*
-import minxie.space.metrics.vo.MetricBaseVo
+import io.netty.util.concurrent.DefaultThreadFactory
+import minxie.space.jvm.vo.metrics.ClassMetricVo
+import minxie.space.jvm.vo.metrics.GcMetricVo
+import minxie.space.jvm.vo.metrics.JvmInfoMetricVo
+import minxie.space.jvm.vo.metrics.MemoryMetricVo
+import minxie.space.jvm.vo.metrics.ProcessMetricVo
+import minxie.space.jvm.vo.metrics.ThreadMetricVo
 import minxie.space.metrics.vo.MetricsContext
 import minxie.space.thread.metrics.DubboThreadPoolMetricsVo
 import minxie.space.thread.metrics.JdkThreadPoolMetricsVo
@@ -22,8 +27,8 @@ class MetricHttpServer {
     @Throws(Exception::class)
     fun start() {
         println("MetricHttpServer start on port ${MetricsContext.getMetricsConfig().port} applicationName-${MetricsContext.getMetricsConfig().applicationName}")
-        val bossGroup: EventLoopGroup = NioEventLoopGroup()
-        val workerGroup: EventLoopGroup = NioEventLoopGroup()
+        val bossGroup: EventLoopGroup = NioEventLoopGroup(DefaultThreadFactory("bossGroup", true))
+        val workerGroup: EventLoopGroup = NioEventLoopGroup(DefaultThreadFactory("workerGroup", true))
         try {
             val b = ServerBootstrap()
             b.group(bossGroup, workerGroup)


### PR DESCRIPTION
[ISSUE #37 ]  将MetricHttpServer线程设置为守护线程，防止影响应用退出